### PR TITLE
Disable all inlining if no-inlining flag applied

### DIFF
--- a/src/cbmc/cbmc_parse_options.cpp
+++ b/src/cbmc/cbmc_parse_options.cpp
@@ -909,8 +909,11 @@ bool cbmc_parse_optionst::process_goto_program(
     }
   
     // do partial inlining
-    status() << "Partial Inlining" << eom;
-    goto_partial_inline(goto_functions, ns, ui_message_handler);
+    if(!cmdline.isset("no-inlining"))
+    {
+      status() << "Partial Inlining" << eom;
+      goto_partial_inline(goto_functions, ns, ui_message_handler);
+    }
     
     // remove returns, gcc vectors, complex
     remove_returns(symbol_table, goto_functions);
@@ -1191,6 +1194,7 @@ void cbmc_parse_optionst::help()
     " --outfile filename           output formula to given file\n"
     " --arrays-uf-never            never turn arrays into uninterpreted functions\n"
     " --arrays-uf-always           always turn arrays into uninterpreted functions\n"
+    " --no-inlining                disable all inlining when generating goto code\n"
     "\n"
     "Other options:\n"
     " --version                    show version and exit\n"

--- a/src/cbmc/cbmc_parse_options.h
+++ b/src/cbmc/cbmc_parse_options.h
@@ -53,6 +53,7 @@ class optionst;
   "(arrays-uf-always)(arrays-uf-never)" \
   "(string-abstraction)(no-arch)(arch):" \
   "(round-to-nearest)(round-to-plus-inf)(round-to-minus-inf)(round-to-zero)" \
+  "(no-inlining)" \
   "(graphml-cex):" \
   "(gen-c-test-case)" \
   "(localize-faults)(localize-faults-method):" \


### PR DESCRIPTION
This is used in test generation. If generating tests for a function that gets inlined, we fail to find the function within the goto program and instead try to call __CPROVER_Initalise 

Fixes issue https://github.com/diffblue/verification-engine-utils/issues/313