### PR TITLE
Fix bug in constant propagation.

### DIFF
--- a/src/analyses/replace_symbol_ext.cpp
+++ b/src/analyses/replace_symbol_ext.cpp
@@ -62,6 +62,13 @@ bool replace_symbol_extt::replace(exprt &dest) const
       return false;
     }
   }
+  // Do not replace p->f.
+  else if(dest.id()==ID_member)
+  {
+    const exprt &struct_op=to_member_expr(dest).struct_op();
+    if (struct_op.id()==ID_dereference)
+      return false;
+  }
 
   Forall_operands(it, dest)
     if(!replace(*it))

--- a/src/util/replace_symbol.cpp
+++ b/src/util/replace_symbol.cpp
@@ -144,6 +144,11 @@ bool replace_symbolt::have_to_replace(const exprt &dest) const
   if(dest.id()==ID_symbol)
     return expr_map.find(dest.get(ID_identifier))!=expr_map.end();
 
+  // Do not replace p->f
+  if (dest.id()==ID_member &&
+      to_member_expr(dest).struct_op().id()==ID_dereference)
+    return false;
+
   forall_operands(it, dest)
     if(have_to_replace(*it))
       return true;


### PR DESCRIPTION
Propagate also to LHS if it produces a symbol (this is useful for *(&object)).
Do not propagate for ptr->field.
If propagation ends with symbol at RHS, repeat recursively.