### PR TITLE
Fixed pretty-printing of strings in the string container.

### DIFF
--- a/src/config.inc
+++ b/src/config.inc
@@ -10,7 +10,7 @@ endif
 
 # Select optimisation or debug info
 #CXXFLAGS += -O2 -DNDEBUG
-#CXXFLAGS += -O0 -g -DDEBUG
+#CXXFLAGS += -O0 -g -DPRETTYPRINT
 
 # If GLPK is available; this is used by goto-instrument and musketeer.
 #LIB_GLPK = -lglpk

--- a/src/config.inc
+++ b/src/config.inc
@@ -10,7 +10,7 @@ endif
 
 # Select optimisation or debug info
 #CXXFLAGS += -O2 -DNDEBUG
-#CXXFLAGS += -O0 -g
+#CXXFLAGS += -O0 -g -DDEBUG
 
 # If GLPK is available; this is used by goto-instrument and musketeer.
 #LIB_GLPK = -lglpk

--- a/src/util/string_container.cpp
+++ b/src/util/string_container.cpp
@@ -75,8 +75,21 @@ unsigned string_containert::get(const std::string &s)
   return r;
 }
 
+const std::string &
+NOINLINE_WHEN_GCC_AND_DEBUG() string_containert::get_string_slowly(
+  size_t no) const
+{
+  return *string_vector[no];
+}
+
+bool NOINLINE_WHEN_GCC_AND_DEBUG() string_containert::is_number_valid(
+  const size_t no) const
+{
+  return no < string_vector.size() && string_vector.at(no) != nullptr;
+}
+
 /// Get a reference to the global string container.
-string_containert &get_string_container()
+string_containert & NOINLINE_WHEN_GCC_AND_DEBUG() get_string_container()
 {
   static string_containert ret;
   return ret;

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -18,7 +18,7 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_hash.h"
 
-#if defined(__GNUC__) && (defined(DEBUG) || defined(_DEBUG))
+#if defined(__GNUC__) && defined(PRETTYPRINT)
 #define NOINLINE_WHEN_GCC_AND_DEBUG() __attribute__ ((noinline, used))
 #else
 #define NOINLINE_WHEN_GCC_AND_DEBUG()

--- a/src/util/string_container.h
+++ b/src/util/string_container.h
@@ -18,6 +18,12 @@ Author: Daniel Kroening, kroening@kroening.com
 
 #include "string_hash.h"
 
+#if defined(__GNUC__) && (defined(DEBUG) || defined(_DEBUG))
+#define NOINLINE_WHEN_GCC_AND_DEBUG() __attribute__ ((noinline, used))
+#else
+#define NOINLINE_WHEN_GCC_AND_DEBUG()
+#endif
+
 struct string_ptrt
 {
   const char *s;
@@ -73,6 +79,11 @@ public:
     return *string_vector[no];
   }
 
+  const std::string &
+  NOINLINE_WHEN_GCC_AND_DEBUG() get_string_slowly(size_t no) const;
+
+  bool NOINLINE_WHEN_GCC_AND_DEBUG() is_number_valid(const size_t no) const;
+
 protected:
   // the 'unsigned' ought to be size_t
   typedef std::unordered_map<string_ptrt, unsigned, string_ptr_hash>
@@ -89,6 +100,6 @@ protected:
   string_vectort string_vector;
 };
 
-string_containert &get_string_container();
+string_containert & NOINLINE_WHEN_GCC_AND_DEBUG() get_string_container();
 
 #endif // CPROVER_UTIL_STRING_CONTAINER_H


### PR DESCRIPTION
Unfortutatelly, the solution with a single free function
does not work. GCC seams to ignore attributes and throws
the function away. Fortunatelly, it does not ignore
attributes, when given to non-static method, and so
the non-debug build can be as fast as before.

Here is the pretty-printer function for QTCreator:
```
def qdump__dstringt(d, value):
    try:
        address = address_of_value(value)
        string_no = str(gdb.parse_and_eval("(*((const dstringt*)" + address + ")).no"))
        has_no = str(gdb.parse_and_eval("get_string_container().is_number_valid(" + string_no +")"))
        if has_no == "true":
            raw_string_value = str(gdb.parse_and_eval("get_string_container().get_string_slowly(" + string_no +")"))
            string_value = raw_string_value.replace("\0", "").replace("\"", "\\\"")
            d.putValue(string_no + ": " + string_value)
        else:
            d.putValue(string_no + ": The number is invalid.")
    except Exception as e:
        d.putValue("Exception getting value of dstringt: " + str(e))
```