### PR TITLE
CLI option for leak checks for abort functions

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -37,6 +37,7 @@ public:
     enable_bounds_check=_options.get_bool_option("bounds-check");
     enable_pointer_check=_options.get_bool_option("pointer-check");
     enable_memory_leak_check=_options.get_bool_option("memory-leak-check");
+    enable_memory_cleanup_check=_options.get_bool_option("memory-cleanup-check");
     enable_div_by_zero_check=_options.get_bool_option("div-by-zero-check");
     enable_signed_overflow_check=_options.get_bool_option("signed-overflow-check");
     enable_unsigned_overflow_check=_options.get_bool_option("unsigned-overflow-check");
@@ -104,6 +105,7 @@ protected:
   bool enable_bounds_check;
   bool enable_pointer_check;
   bool enable_memory_leak_check;
+  bool enable_memory_cleanup_check;
   bool enable_div_by_zero_check;
   bool enable_signed_overflow_check;
   bool enable_unsigned_overflow_check;
@@ -1747,7 +1749,7 @@ void goto_checkt::goto_check(goto_functiont &goto_function)
       // These are further 'exit points' of the program
       const exprt simplified_guard = simplify_expr(i.guard, ns);
       if(
-        enable_memory_leak_check && simplified_guard.is_false() &&
+        enable_memory_cleanup_check && simplified_guard.is_false() &&
         (i.function == "abort" || i.function == "exit" ||
          i.function == "_Exit" ||
          (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -30,7 +30,7 @@ void goto_check(
   goto_modelt &goto_model);
 
 #define GOTO_CHECK_OPTIONS \
-  "(bounds-check)(pointer-check)(memory-leak-check)" \
+  "(bounds-check)(pointer-check)(memory-leak-check)(memory-cleanup-check)" \
   "(div-by-zero-check)(signed-overflow-check)(unsigned-overflow-check)" \
   "(pointer-overflow-check)(conversion-check)(undefined-shift-check)" \
   "(float-overflow-check)(nan-check)"
@@ -39,6 +39,7 @@ void goto_check(
   " --bounds-check               enable array bounds checks\n" \
   " --pointer-check              enable pointer checks\n" \
   " --memory-leak-check          enable memory leak checks\n" \
+  " --memory-cleanup-check       enable memory cleanup checks\n" \
   " --div-by-zero-check          enable division by zero checks\n" \
   " --signed-overflow-check      enable signed arithmetic over- and underflow checks\n" \
   " --unsigned-overflow-check    enable arithmetic over- and underflow checks\n" \
@@ -52,6 +53,7 @@ void goto_check(
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
   options.set_option("pointer-check", cmdline.isset("pointer-check")); \
   options.set_option("memory-leak-check", cmdline.isset("memory-leak-check")); \
+  options.set_option("memory-cleanup-check", cmdline.isset("memory-cleanup-check")); \
   options.set_option("div-by-zero-check", cmdline.isset("div-by-zero-check")); \
   options.set_option("signed-overflow-check", cmdline.isset("signed-overflow-check")); \
   options.set_option("unsigned-overflow-check", cmdline.isset("unsigned-overflow-check")); \


### PR DESCRIPTION
Add a new CLI option `--memory-cleanup-check` and add memory leak assertions for abort functions only if the option is on.

This complies with the SV-COMP rules where memory leaks on `__VERIFIER_error` calls are checked only for the `valid-memcleanup` property, otherwise they are ignored.