### PR TITLE
2ls prerequisites 0.9.1

### DIFF
--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -365,10 +365,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
           xmlt &data_l=edge.new_element("data");
           data_l.set_attribute("key", "startline");
           data_l.data=id2string(graphml[from].line);
-
-          xmlt &data_t=edge.new_element("data");
-          data_t.set_attribute("key", "threadId");
-          data_t.data=std::to_string(it->thread_nr);
         }
 
         if((it->type==goto_trace_stept::ASSIGNMENT ||

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -381,7 +381,7 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     xmlt &key=graphml.new_element("key");
     key.set_attribute("attr.name", "cyclehead");
     key.set_attribute("attr.type", "boolean");
-    key.set_attribute("for", "edge");
+    key.set_attribute("for", "node");
     key.set_attribute("id", "cyclehead");
 
     key.new_element("default").data="false";

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -460,6 +460,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "architecture");
   }
 
+  // <key attr.name="creationTime" attr.type="string" for="graph"
+  //      id="creationtime"/>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "creationTime");
+    key.set_attribute("attr.type", "string");
+    key.set_attribute("for", "graph");
+    key.set_attribute("id", "creationtime");
+  }
+
   // <key attr.name="producer" attr.type="string" for="graph"
   //      id="producer"/>
   {


### PR DESCRIPTION
Contains fixes of witness files so that they comply with SV-COMP requested format that is now checked by the WitnessLint tool.

Changes are:
- added `creationtime` attribute (it is set by the wrapper script)
- removed `threadId` attribute (used for concurrency only)
- fixed `cyclehead` (moved from edge to node)

The PR is open against *2ls-prerequisites-0.8* branch, but should be merged into a new *2ls-prerequisites-0.9.1* branch. It will be followed by a PR to the 2LS repo. Feel free to use rebase, I'll update the new 2LS branch once this is merged.