### PR TITLE
Rebase to CBMC 5.9

### DIFF
--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  if(*p == 0)
+    abort();
+  if(*p == 1)
+    exit(1);
+  if(*p == 2)
+    _Exit(1);
+  free(p);
+  return 0;
+}

--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int main()
 {
@@ -11,6 +11,8 @@ int main()
     exit(1);
   if(*p == 2)
     _Exit(1);
+  if(*p == 3)
+    __VERIFIER_error();
   free(p);
   return 0;
 }

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---memory-leak-check
+--memory-leak-check --no-assertions
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
@@ -8,5 +8,7 @@ _Exit\.memory-leak\.1.*FAILURE
 __CPROVER__start\.memory-leak\.1.*SUCCESS
 abort\.memory-leak\.1.*FAILURE
 exit\.memory-leak\.1.*FAILURE
+main\.memory-leak\.1.*FAILURE
 --
+main\.assertion\.1.*FAILURE
 ^warning: ignoring

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--memory-leak-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+_Exit\.memory-leak\.1.*FAILURE
+__CPROVER__start\.memory-leak\.1.*SUCCESS
+abort\.memory-leak\.1.*FAILURE
+exit\.memory-leak\.1.*FAILURE
+--
+^warning: ignoring

--- a/src/Makefile
+++ b/src/Makefile
@@ -86,7 +86,7 @@ $(patsubst %, %_clean, $(DIRS)):
 
 # minisat2 and glucose download, for your convenience
 
-DOWNLOADER = lwp-download
+DOWNLOADER = wget
 TAR = tar
 
 minisat2-download:

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1710,7 +1710,8 @@ void goto_checkt::goto_check(
       if(
         enable_memory_leak_check && simplified_guard.is_false() &&
         (i.function == "abort" || i.function == "exit" ||
-         i.function == "_Exit"))
+         i.function == "_Exit" ||
+         (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))
       {
         memory_leak_check(i.function);
       }

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -47,6 +47,7 @@ public:
     enable_bounds_check=_options.get_bool_option("bounds-check");
     enable_pointer_check=_options.get_bool_option("pointer-check");
     enable_memory_leak_check=_options.get_bool_option("memory-leak-check");
+    enable_memory_cleanup_check=_options.get_bool_option("memory-cleanup-check");
     enable_div_by_zero_check=_options.get_bool_option("div-by-zero-check");
     enable_signed_overflow_check=
       _options.get_bool_option("signed-overflow-check");
@@ -122,6 +123,7 @@ protected:
   bool enable_bounds_check;
   bool enable_pointer_check;
   bool enable_memory_leak_check;
+  bool enable_memory_cleanup_check;
   bool enable_div_by_zero_check;
   bool enable_signed_overflow_check;
   bool enable_unsigned_overflow_check;
@@ -1708,7 +1710,7 @@ void goto_checkt::goto_check(
       // These are further 'exit points' of the program
       const exprt simplified_guard = simplify_expr(i.guard, ns);
       if(
-        enable_memory_leak_check && simplified_guard.is_false() &&
+        enable_memory_cleanup_check && simplified_guard.is_false() &&
         (i.function == "abort" || i.function == "exit" ||
          i.function == "_Exit" ||
          (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -101,6 +101,7 @@ protected:
   void conversion_check(const exprt &expr, const guardt &guard);
   void float_overflow_check(const exprt &expr, const guardt &guard);
   void nan_check(const exprt &expr, const guardt &guard);
+  void memory_leak_check(const irep_idt &function_id);
 
   std::string array_name(const exprt &expr);
 
@@ -1496,6 +1497,55 @@ void goto_checkt::check(const exprt &expr)
   check_rec(expr, guard, false);
 }
 
+/*******************************************************************\
+
+Function: goto_checkt::memory_leak_check
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void goto_checkt::memory_leak_check(const irep_idt &function_id)
+{
+  const symbolt &leak=ns.lookup(CPROVER_PREFIX "memory_leak");
+  const symbol_exprt leak_expr=leak.symbol_expr();
+
+  // add self-assignment to get helpful counterexample output
+  goto_programt::targett t=new_code.add_instruction();
+  t->make_assignment();
+  t->code=code_assignt(leak_expr, leak_expr);
+
+  source_locationt source_location;
+  source_location.set_function(function_id);
+
+  equal_exprt eq(
+    leak_expr,
+    null_pointer_exprt(to_pointer_type(leak.type)));
+  add_guarded_claim(
+    eq,
+    "dynamically allocated memory never freed",
+    "memory-leak",
+    source_location,
+    eq,
+    guardt());
+}
+
+/*******************************************************************\
+
+Function: goto_checkt::goto_check
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:[B
+
+\*******************************************************************/
+
 void goto_checkt::goto_check(
   goto_functiont &goto_function,
   const irep_idt &_mode)
@@ -1690,30 +1740,11 @@ void goto_checkt::goto_check(
     }
     else if(i.is_end_function())
     {
-      if(i.function==goto_functionst::entry_point() &&
-         enable_memory_leak_check)
+      if(
+        i.function == goto_functionst::entry_point() &&
+        enable_memory_leak_check)
       {
-        const symbolt &leak=ns.lookup(CPROVER_PREFIX "memory_leak");
-        const symbol_exprt leak_expr=leak.symbol_expr();
-
-        // add self-assignment to get helpful counterexample output
-        goto_programt::targett t=new_code.add_instruction();
-        t->make_assignment();
-        t->code=code_assignt(leak_expr, leak_expr);
-
-        source_locationt source_location;
-        source_location.set_function(i.function);
-
-        equal_exprt eq(
-          leak_expr,
-          null_pointer_exprt(to_pointer_type(leak.type)));
-        add_guarded_claim(
-          eq,
-          "dynamically allocated memory never freed",
-          "memory-leak",
-          source_location,
-          eq,
-          guardt());
+        memory_leak_check(i.function);
       }
     }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -1705,6 +1705,15 @@ void goto_checkt::goto_check(
     }
     else if(i.is_assume())
     {
+      // These are further 'exit points' of the program
+      const exprt simplified_guard = simplify_expr(i.guard, ns);
+      if(
+        enable_memory_leak_check && simplified_guard.is_false() &&
+        (i.function == "abort" || i.function == "exit" ||
+         i.function == "_Exit"))
+      {
+        memory_leak_check(i.function);
+      }
       if(!enable_assumptions)
       {
         i.make_skip();

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -34,7 +34,7 @@ void goto_check(
   goto_modelt &goto_model);
 
 #define OPT_GOTO_CHECK \
-  "(bounds-check)(pointer-check)(memory-leak-check)" \
+  "(bounds-check)(pointer-check)(memory-leak-check)(memory-cleanup-check)" \
   "(div-by-zero-check)(signed-overflow-check)(unsigned-overflow-check)" \
   "(pointer-overflow-check)(conversion-check)(undefined-shift-check)" \
   "(float-overflow-check)(nan-check)(no-built-in-assertions)"
@@ -43,6 +43,7 @@ void goto_check(
   " --bounds-check               enable array bounds checks\n" \
   " --pointer-check              enable pointer checks (always enabled for Java)\n" /* NOLINT(whitespace/line_length) */ \
   " --memory-leak-check          enable memory leak checks\n" \
+  " --memory-cleanup-check       enable memory cleanup checks\n" \
   " --div-by-zero-check          enable division by zero checks\n" \
   " --signed-overflow-check      enable signed arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */ \
   " --unsigned-overflow-check    enable arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */  \
@@ -57,6 +58,7 @@ void goto_check(
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
   options.set_option("pointer-check", cmdline.isset("pointer-check")); \
   options.set_option("memory-leak-check", cmdline.isset("memory-leak-check")); \
+  options.set_option("memory-cleanup-check", cmdline.isset("memory-cleanup-check")); \
   options.set_option("div-by-zero-check", cmdline.isset("div-by-zero-check")); \
   options.set_option("signed-overflow-check", cmdline.isset("signed-overflow-check")); /* NOLINT(whitespace/line_length) */  \
   options.set_option("unsigned-overflow-check", cmdline.isset("unsigned-overflow-check")); /* NOLINT(whitespace/line_length) */  \

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -168,10 +168,12 @@ inline void free(void *ptr)
 
   // catch people who try to use free(...) for stuff
   // allocated with new[]
+#if 0
   __CPROVER_precondition(ptr==0 ||
                          __CPROVER_malloc_object!=ptr ||
                          !__CPROVER_malloc_is_new_array,
                          "free called for new[] object");
+#endif
 
   if(ptr!=0)
   {

--- a/src/config.inc
+++ b/src/config.inc
@@ -23,7 +23,7 @@ endif
 #MINISAT = ../../MiniSat-p_v1.14
 #MINISAT2 = ../../minisat-2.2.1
 #IPASIR = ../../ipasir
-#GLUCOSE = ../../glucose-syrup
+GLUCOSE = ../../glucose-syrup
 #CADICAL = ../../cadical
 
 # Extra library for SAT solver. This should link to the archive file to be used

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,7 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations
+  CXXFLAGS += -Wall -pedantic -Wno-deprecated-declarations
 endif
 
 # Select optimisation or debug info

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -733,6 +733,7 @@ void goto_convertt::do_function_call_symbol(
     // are being checked
     goto_programt::targett a=dest.add_instruction(ASSUME);
     a->guard=false_exprt();
+    a->labels.push_back("__VERIFIER_abort");
     a->source_location=function.source_location();
     a->source_location.set("user-provided", true);
   }

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -45,8 +45,10 @@ void goto_inline(
     ns,
     message_handler,
     adjust_function);
+  goto_inline();
+}
 
-  typedef goto_functionst::goto_functiont goto_functiont;
+void goto_inlinet::operator()() {
 
   // find entry point
   goto_functionst::function_mapt::iterator it=
@@ -85,7 +87,7 @@ void goto_inline(
     }
   }
 
-  goto_inline.goto_inline(
+  goto_inline(
     goto_functionst::entry_point(), goto_function, inline_map, true);
 
   // clean up

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -112,6 +112,11 @@ void goto_inlinet::parameter_assignments(
         {
           actual.make_typecast(par_type);
         }
+        else if(f_partype.id()==ID_floatbv &&
+                f_acttype.id()==ID_floatbv)
+        {
+          actual.make_typecast(par_type);
+        }
         else if((f_partype.id()==ID_signedbv ||
                  f_partype.id()==ID_unsignedbv ||
                  f_partype.id()==ID_bool) &&

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -418,6 +418,7 @@ void goto_inlinet::expand_function_call(
     warning().source_location=function.find_source_location();
     warning() << "recursion is ignored on call to `" << identifier << "'"
               << eom;
+    is_recursion_detected=true;
 
     if(force_full)
       target->make_skip();

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -31,7 +31,8 @@ public:
     goto_functions(goto_functions),
     ns(ns),
     adjust_function(adjust_function),
-    caching(caching)
+    caching(caching),
+    is_recursion_detected(false)
   {
   }
 
@@ -47,6 +48,9 @@ public:
 
   // list of calls per function that should be inlined
   typedef std::map<irep_idt, call_listt> inline_mapt;
+
+  void operator()();
+  bool recursion_detected() { return is_recursion_detected; }
 
   // handle given goto function
   // force_full:
@@ -128,6 +132,7 @@ protected:
 
   const bool adjust_function;
   const bool caching;
+  bool is_recursion_detected;
 
   goto_inline_logt inline_log;
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -575,17 +575,6 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
           graphml[to].invariant_scope=
             id2string(it->source.pc->source_location.get_function());
         }
-        else if(it->is_goto() &&
-                it->source.pc->is_goto())
-        {
-          xmlt &val=edge.new_element("data");
-          val.set_attribute("key", "sourcecode");
-          exprt clean_cond=it->cond_expr;
-          remove_l0_l1(clean_cond);
-          const std::string cond=from_expr(ns, "", clean_cond);
-            from_expr(ns, "", not_exprt(clean_cond));
-          val.data="["+cond+"]";
-        }
 
         graphml[to].in[from].xml_node=edge;
         graphml[from].out[to].xml_node=edge;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -138,7 +138,9 @@ std::string graphml_witnesst::convert_assign_rec(
     exprt clean_rhs=assign.rhs();
     remove_l0_l1(clean_rhs);
 
-    std::string lhs=from_expr(ns, identifier, assign.lhs());
+    exprt clean_lhs=assign.lhs();
+    remove_l0_l1(clean_lhs);
+    std::string lhs=from_expr(ns, identifier, clean_lhs);
     if(lhs.find('$')!=std::string::npos)
       lhs="\\result";
 
@@ -345,10 +347,11 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         {
           xmlt &val=edge.new_element("data");
           val.set_attribute("key", "sourcecode");
-          const std::string cond =
-            from_expr(ns, it->pc->function, it->cond_expr);
+          exprt clean_cond=it->cond_expr;
+          remove_l0_l1(clean_cond);
+          const std::string cond=from_expr(ns, "", clean_cond);
           const std::string neg_cond=
-            from_expr(ns, it->pc->function, not_exprt(it->cond_expr));
+            from_expr(ns, "", not_exprt(clean_cond));
           val.data="["+(it->cond_value ? cond : neg_cond)+"]";
 
           #if 0
@@ -527,8 +530,10 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
         {
           xmlt &val=edge.new_element("data");
           val.set_attribute("key", "sourcecode");
-          const std::string cond =
-            from_expr(ns, it->source.pc->function, it->cond_expr);
+          exprt clean_cond=it->cond_expr;
+          remove_l0_l1(clean_cond);
+          const std::string cond=from_expr(ns, "", clean_cond);
+            from_expr(ns, "", not_exprt(clean_cond));
           val.data="["+cond+"]";
         }
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -253,9 +253,23 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     {
       // advance
     }
-    const std::size_t to=
-      next==goto_trace.steps.end()?
-      sink:step_to_node[next->step_nr];
+
+    std::size_t to=sink;
+    // nontermination lasso traces end in a backwards goto:
+    if(next==goto_trace.steps.end() &&
+       it->is_goto() && it->pc->is_backwards_goto())
+    {
+      goto_tracet::stepst::const_iterator last=it;
+      for(--last; last->pc==it->pc->get_target(); --last)
+        ;
+      // we'll close the loop
+      to=step_to_node[last->step_nr];
+    }
+    else
+    {
+      // advance to the next step
+      to=step_to_node[next->step_nr];
+    }
 
     switch(it->type)
     {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -237,6 +237,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     graphml[node].is_violation=
       it->type==goto_trace_stept::typet::ASSERT && !it->cond_value;
     graphml[node].has_invariant=false;
+    graphml[node].is_cyclehead=false;
 
     step_to_node[it->step_nr]=node;
   }
@@ -277,6 +278,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         ;
       // we'll close the loop
       to=step_to_node[last->step_nr];
+      graphml[to].is_cyclehead=true;
     }
     else
     {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -345,35 +345,13 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         else if(it->type==goto_trace_stept::typet::GOTO &&
                 it->pc->is_goto())
         {
+#if 0
+          // TODO: this requires knowledge about the phase of the
+          //   condition in the source code
           xmlt &val=edge.new_element("data");
-          val.set_attribute("key", "sourcecode");
-          exprt clean_cond=it->cond_expr;
-          remove_l0_l1(clean_cond);
-          const std::string cond=from_expr(ns, "", clean_cond);
-          const std::string neg_cond=
-            from_expr(ns, "", not_exprt(clean_cond));
-          val.data="["+(it->cond_value ? cond : neg_cond)+"]";
-
-          #if 0
-          xmlt edge2("edge");
-          edge2.set_attribute("source", graphml[from].node_name);
-          edge2.set_attribute("target", graphml[sink].node_name);
-
-          xmlt &data_f2=edge2.new_element("data");
-          data_f2.set_attribute("key", "originfile");
-          data_f2.data=id2string(graphml[from].file);
-
-          xmlt &data_l2=edge2.new_element("data");
-          data_l2.set_attribute("key", "startline");
-          data_l2.data=id2string(graphml[from].line);
-
-          xmlt &val2=edge2.new_element("data");
-          val2.set_attribute("key", "sourcecode");
-          val2.data="["+(it->cond_value ? neg_cond : cond)+"]";
-
-          graphml[sink].in[from].xml_node=edge2;
-          graphml[from].out[sink].xml_node=edge2;
-          #endif
+          val.set_attribute("key", "control");
+          val.data=(it->cond_value?"condition-false":"condition-true");
+#endif
         }
 
         graphml[to].in[from].xml_node=edge;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -17,6 +17,8 @@ Author: Daniel Kroening
 #include <util/arith_tools.h>
 #include <util/prefix.h>
 #include <util/ssa_expr.h>
+#include <util/std_pair_hash.h>
+#include <unordered_map>
 
 #include <langapi/language_util.h>
 
@@ -52,6 +54,13 @@ std::string graphml_witnesst::convert_assign_rec(
   const irep_idt &identifier,
   const code_assignt &assign)
 {
+  static std::unordered_map<std::pair<unsigned int, const irept::dt *>, std::string> cache;
+  {
+      const auto cit = cache.find({identifier.get_no(), &assign.read()});
+      if(cit != cache.end())
+          return cit->second;
+  }
+
   std::string result;
 
   if(assign.rhs().id()==ID_array)
@@ -136,6 +145,7 @@ std::string graphml_witnesst::convert_assign_rec(
     result=lhs+" = "+from_expr(ns, identifier, clean_rhs)+";";
   }
 
+  cache.insert({{identifier.get_no(), &assign.read()}, result});
   return result;
 }
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -191,7 +191,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
 
   const graphmlt::node_indext sink=graphml.add_node();
   graphml[sink].node_name="sink";
-  graphml[sink].thread_nr=0;
   graphml[sink].is_violation=false;
   graphml[sink].has_invariant=false;
 
@@ -233,13 +232,14 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
       std::to_string(it->pc->location_number)+"."+std::to_string(it->step_nr);
     graphml[node].file=source_location.get_file();
     graphml[node].line=source_location.get_line();
-    graphml[node].thread_nr=it->thread_nr;
     graphml[node].is_violation=
       it->type==goto_trace_stept::typet::ASSERT && !it->cond_value;
     graphml[node].has_invariant=false;
 
     step_to_node[it->step_nr]=node;
   }
+
+  std::size_t thread_id=0;
 
   // build edges
   for(goto_tracet::stepst::const_iterator
@@ -287,6 +287,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     case goto_trace_stept::typet::ASSIGNMENT:
     case goto_trace_stept::typet::ASSERT:
     case goto_trace_stept::typet::GOTO:
+    case goto_trace_stept::typet::SPAWN:
       {
         xmlt edge("edge");
         edge.set_attribute("source", graphml[from].node_name);
@@ -300,16 +301,33 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
           xmlt &data_l=edge.new_element("data");
           data_l.set_attribute("key", "startline");
           data_l.data=id2string(graphml[from].line);
+
+          xmlt &data_t=edge.new_element("data");
+          data_t.set_attribute("key", "threadId");
+          data_t.data=std::to_string(it->thread_nr);
         }
 
         if(it->type==goto_trace_stept::typet::ASSIGNMENT &&
            it->lhs_object_value.is_not_nil() &&
            it->full_lhs.is_not_nil())
         {
-          if(!it->lhs_object_value.is_constant() ||
-             !it->lhs_object_value.has_operands() ||
-             !has_prefix(id2string(it->lhs_object_value.op0().get(ID_value)),
-                         "INVALID-"))
+          if(id2string(it->lhs_object.get_identifier())
+             .find("pthread_create::thread")!=std::string::npos)
+          {
+            xmlt &data_t=edge.new_element("data");
+            data_t.set_attribute("key", "createThread");
+            data_t.data=std::to_string(++thread_id);
+          }
+          else if(id2string(it->lhs_object.get_identifier())
+               .find("#return_value")==std::string::npos &&
+             id2string(it->lhs_object.get_identifier())
+               .find("thread")==std::string::npos &&
+             id2string(it->lhs_object.get_identifier())
+               .find("mutex")==std::string::npos &&
+             (!it->lhs_object_value.is_constant() ||
+              !it->lhs_object_value.has_operands() ||
+              !has_prefix(id2string(it->lhs_object_value.op0().get(ID_value)),
+                          "INVALID-")))
           {
             xmlt &val=edge.new_element("data");
             val.set_attribute("key", "assumption");
@@ -369,7 +387,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     case goto_trace_stept::typet::OUTPUT:
     case goto_trace_stept::typet::SHARED_READ:
     case goto_trace_stept::typet::SHARED_WRITE:
-    case goto_trace_stept::typet::SPAWN:
     case goto_trace_stept::typet::MEMORY_BARRIER:
     case goto_trace_stept::typet::ATOMIC_BEGIN:
     case goto_trace_stept::typet::ATOMIC_END:
@@ -391,7 +408,6 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
 
   const graphmlt::node_indext sink=graphml.add_node();
   graphml[sink].node_name="sink";
-  graphml[sink].thread_nr=0;
   graphml[sink].is_violation=false;
   graphml[sink].has_invariant=false;
 
@@ -437,7 +453,6 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
       std::to_string(step_nr);
     graphml[node].file=source_location.get_file();
     graphml[node].line=source_location.get_line();
-    graphml[node].thread_nr=it->source.thread_nr;
     graphml[node].is_violation=false;
     graphml[node].has_invariant=false;
 
@@ -478,6 +493,7 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
     case goto_trace_stept::typet::ASSIGNMENT:
     case goto_trace_stept::typet::ASSERT:
     case goto_trace_stept::typet::GOTO:
+    case goto_trace_stept::typet::SPAWN:
       {
         xmlt edge("edge");
         edge.set_attribute("source", graphml[from].node_name);
@@ -530,7 +546,6 @@ void graphml_witnesst::operator()(const symex_target_equationt &equation)
     case goto_trace_stept::typet::OUTPUT:
     case goto_trace_stept::typet::SHARED_READ:
     case goto_trace_stept::typet::SHARED_WRITE:
-    case goto_trace_stept::typet::SPAWN:
     case goto_trace_stept::typet::MEMORY_BARRIER:
     case goto_trace_stept::typet::ATOMIC_BEGIN:
     case goto_trace_stept::typet::ATOMIC_END:

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -370,10 +370,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
           xmlt &data_l=edge.new_element("data");
           data_l.set_attribute("key", "startline");
           data_l.data=id2string(graphml[from].line);
-
-          xmlt &data_t=edge.new_element("data");
-          data_t.set_attribute("key", "threadId");
-          data_t.data=std::to_string(it->thread_nr);
         }
 
         if(it->type==goto_trace_stept::typet::ASSIGNMENT &&

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -239,7 +239,8 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
   {
     const std::size_t from=step_to_node[it->step_nr];
 
-    if(from==sink)
+    // no outgoing edges from sinks or violation nodes
+    if(from==sink || graphml[from].is_violation)
     {
       ++it;
       continue;

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -269,21 +269,39 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     }
 
     std::size_t to=sink;
-    // nontermination lasso traces end in a backwards goto:
-    if(next==goto_trace.steps.end() &&
-       it->is_goto() && it->pc->is_backwards_goto())
+    if(next!=goto_trace.steps.end())
     {
-      goto_tracet::stepst::const_iterator last=it;
-      for(--last; last->pc==it->pc->get_target(); --last)
-        ;
-      // we'll close the loop
-      to=step_to_node[last->step_nr];
-      graphml[to].is_cyclehead=true;
+      goto_tracet::stepst::const_iterator after_next=next;
+      ++after_next;
+      // nontermination lasso traces do not end in assertions
+      if(after_next==goto_trace.steps.end() &&
+         !next->is_assert())
+      {
+        goto_tracet::stepst::const_iterator last=
+          goto_trace.steps.begin();
+        for(goto_tracet::stepst::const_iterator last_it=
+              goto_trace.steps.begin();
+            last_it!=goto_trace.steps.end() &&
+            last_it!=next;
+            ++last_it)
+        {
+          if(last_it->pc==next->pc)
+            last=last_it;
+        }
+        // we'll close the loop
+        to=step_to_node[last->step_nr];
+        graphml[to].is_cyclehead=true;
+      }
+      else
+      {
+        // advance to the next step
+        to=step_to_node[next->step_nr];
+      }
     }
-    else
+    else if(!it->is_assert())
     {
-      // advance to the next step
-      to=step_to_node[next->step_nr];
+      // do not output recurrent step in nontermination trace
+      break;
     }
 
     switch(it->type)

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -63,7 +63,27 @@ std::string graphml_witnesst::convert_assign_rec(
 
   std::string result;
 
-  if(assign.rhs().id()==ID_array)
+  if(assign.rhs().id()=="array-list")
+  {
+    const array_typet &type=
+      to_array_type(ns.follow(assign.rhs().type()));
+
+    const auto ops=assign.rhs().operands();
+    assert(ops.size()%2==0);
+
+    for(size_t listidx=0; listidx!=ops.size(); listidx+=2)
+    {
+      index_exprt index(
+        assign.lhs(),
+        ops[listidx],
+        type.subtype());
+      if(!result.empty())
+        result+=' ';
+      result+=
+        convert_assign_rec(identifier, code_assignt(index, ops[listidx+1]));
+    }
+  }
+  else if(assign.rhs().id()==ID_array)
   {
     const array_typet &type=
       to_array_type(ns.follow(assign.rhs().type()));
@@ -146,7 +166,6 @@ std::string graphml_witnesst::convert_assign_rec(
 
     result=lhs+" = "+from_expr(ns, identifier, clean_rhs)+";";
   }
-
   cache.insert({{identifier.get_no(), &assign.read()}, result});
   return result;
 }
@@ -185,6 +204,34 @@ static bool filter_out(
 
   return false;
 }
+
+static bool contains_symbol_prefix(const exprt &expr, const std::string &prefix){
+  if(expr.id()==ID_symbol &&
+     has_prefix(id2string(to_symbol_expr(expr).get_identifier()), prefix))
+  {
+    return true;
+  }
+
+  forall_operands(it, expr)
+  {
+    if(contains_symbol_prefix(*it, prefix))
+      return true;
+  }
+  return false;
+}
+
+
+/*******************************************************************\
+
+Function: graphml_witnesst::operator()
+
+  Inputs:
+
+ Outputs:
+
+ Purpose: counterexample witness
+
+\*******************************************************************/
 
 /// counterexample witness
 void graphml_witnesst::operator()(const goto_tracet &goto_trace)
@@ -340,16 +387,21 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
             data_t.set_attribute("key", "createThread");
             data_t.data=std::to_string(++thread_id);
           }
-          else if(id2string(it->lhs_object.get_identifier())
-               .find("#return_value")==std::string::npos &&
-             id2string(it->lhs_object.get_identifier())
-               .find("thread")==std::string::npos &&
-             id2string(it->lhs_object.get_identifier())
-               .find("mutex")==std::string::npos &&
-             (!it->lhs_object_value.is_constant() ||
-              !it->lhs_object_value.has_operands() ||
-              !has_prefix(id2string(it->lhs_object_value.op0().get(ID_value)),
-                          "INVALID-")))
+          else if(
+            id2string(it->lhs_object.get_identifier())
+              .find("#return_value")==std::string::npos &&
+            !contains_symbol_prefix(
+              it->lhs_object_value, "symex_dynamic::dynamic_object") &&
+            !contains_symbol_prefix(
+              it->lhs_object, "symex_dynamic::dynamic_object") &&
+            id2string(it->lhs_object.get_identifier())
+              .find("thread")==std::string::npos &&
+            id2string(it->lhs_object.get_identifier())
+              .find("mutex")==std::string::npos &&
+            (!it->lhs_object_value.is_constant() ||
+             !it->lhs_object_value.has_operands() ||
+             !has_prefix(id2string(it->lhs_object_value.op0().get(ID_value)),
+                         "INVALID-")))
           {
             xmlt &val=edge.new_element("data");
             val.set_attribute("key", "assumption");

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -118,9 +118,11 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   {
     const mp_integer offset = *index * byte_width;
 
-    for(std::size_t i=0; i<width; i++)
+    long offset_i=offset.to_long();
+
+    for(long i=0; i<(long)width; i++)
       // out of bounds?
-      if(offset + i < 0 || offset + i >= op_bv.size())
+      if(offset<0 || offset_i+i>=(long)op_bv.size())
         bv[i]=prop.new_variable();
       else
         bv[i] = op_bv[numeric_cast_v<std::size_t>(offset) + i];

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -454,6 +454,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
 
   if(ns.follow(expr.type()).id()==ID_floatbv)
   {
+#if 0
     // we only merge neighboring constants!
     Forall_expr(it, operands)
     {
@@ -471,6 +472,7 @@ bool simplify_exprt::simplify_plus(exprt &expr)
         }
       }
     }
+#endif
   }
   else
   {

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -548,7 +548,8 @@ bool simplify_exprt::simplify_dynamic_object(exprt &expr)
       const irep_idt identifier=to_symbol_expr(op.op0()).get_identifier();
 
       // this is for the benefit of symex
-      expr.make_bool(has_prefix(id2string(identifier), "symex_dynamic::"));
+      expr.make_bool(has_prefix(id2string(identifier), "symex_dynamic::") ||
+                     op.op0().type().get_bool("#dynamic"));
       return false;
     }
     else if(op.op0().id()==ID_string_constant)

--- a/src/util/std_pair_hash.h
+++ b/src/util/std_pair_hash.h
@@ -1,0 +1,35 @@
+/*******************************************************************\
+
+Module: util/std_pair_hash
+
+Author: Marek Trtik, marek.trtik@diffblue.com
+
+\*******************************************************************/
+
+#ifndef CPROVER_UTIL_STD_PAIR_HASH_H
+#define CPROVER_UTIL_STD_PAIR_HASH_H
+
+#include <functional>
+
+template <typename T>
+inline void hash_combine(std::size_t & seed, const T & v)
+{
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+namespace std
+{
+  template<typename S, typename T> struct hash<pair<S, T> >
+  {
+    inline size_t operator()(const pair<S, T> & v) const
+    {
+      size_t seed = 0;
+      ::hash_combine(seed, v.first);
+      ::hash_combine(seed, v.second);
+      return seed;
+    }
+  };
+}
+
+#endif

--- a/src/util/symbol_table_base.h
+++ b/src/util/symbol_table_base.h
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <unordered_map>
+#include <stdexcept>
 
 #include "symbol.h"
 

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -403,15 +403,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "producer");
   }
 
-  // <key attr.name="sourcecode" attr.type="string" for="edge" id="sourcecode"/>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "sourcecode");
-    key.set_attribute("attr.type", "string");
-    key.set_attribute("for", "edge");
-    key.set_attribute("id", "sourcecode");
-  }
-
   // <key attr.name="startline" attr.type="int" for="edge" id="startline"/>
   {
     xmlt &key=graphml.new_element("key");

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -54,7 +54,6 @@ static bool build_graph_rec(
     node.node_name=node_name;
     node.is_violation=false;
     node.has_invariant=false;
-    node.thread_nr=0;
 
     for(xmlt::elementst::const_iterator
         e_it=xml.elements.begin();
@@ -66,8 +65,6 @@ static bool build_graph_rec(
       if(e_it->get_attribute("key")=="violation" &&
          e_it->data=="true")
         node.is_violation=e_it->data=="true";
-      else if(e_it->get_attribute("key")=="threadNumber")
-        node.thread_nr=safe_string2unsigned(e_it->data);
       else if(e_it->get_attribute("key")=="entry" &&
               e_it->data=="true")
         entrynode=node_name;
@@ -337,13 +334,24 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
   }
 
   // <key attr.name="threadId" attr.type="string" for="edge" id="threadId"/>
-  // TODO: format for multi-threaded programs not defined yet
   {
     xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "threadNumber");
+    key.set_attribute("attr.name", "threadId");
     key.set_attribute("attr.type", "int");
-    key.set_attribute("for", "node");
-    key.set_attribute("id", "thread");
+    key.set_attribute("for", "edge");
+    key.set_attribute("id", "threadId");
+
+    key.new_element("default").data="0";
+  }
+
+  // <key attr.name="createThread" attr.type="string"
+  //      for="edge" id="createThread"/>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "createThread");
+    key.set_attribute("attr.type", "int");
+    key.set_attribute("for", "edge");
+    key.set_attribute("id", "createThread");
 
     key.new_element("default").data="0";
   }
@@ -523,13 +531,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
       entry.data="true";
 
       entry_done=true;
-    }
-
-    if(n.thread_nr!=0)
-    {
-      xmlt &entry=node.new_element("data");
-      entry.set_attribute("key", "threadNumber");
-      entry.data=std::to_string(n.thread_nr);
     }
 
     // <node id="A14">

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -252,33 +252,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "invariant.scope");
   }
 
-  // <key attr.name="nodeType" attr.type="string" for="node" id="nodetype">
-  //     <default>path</default>
-  // </key>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "nodeType");
-    key.set_attribute("attr.type", "string");
-    key.set_attribute("for", "node");
-    key.set_attribute("id", "nodetype");
-
-    key.new_element("default").data="path";
-  }
-
-  // <key attr.name="isFrontierNode" attr.type="boolean" for="node"
-  //      id="frontier">
-  //     <default>false</default>
-  // </key>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "isFrontierNode");
-    key.set_attribute("attr.type", "boolean");
-    key.set_attribute("for", "node");
-    key.set_attribute("id", "frontier");
-
-    key.new_element("default").data="false";
-  }
-
   // <key attr.name="isViolationNode" attr.type="boolean" for="node"
   //      id="violation">
   //     <default>false</default>
@@ -329,6 +302,20 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("attr.type", "boolean");
     key.set_attribute("for", "edge");
     key.set_attribute("id", "enterLoopHead");
+
+    key.new_element("default").data="false";
+  }
+
+  // <key attr.name="cyclehead" attr.type="boolean" for="edge"
+  //      id="cyclehead">
+  //   <default>false</default>
+  // </key>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "cyclehead");
+    key.set_attribute("attr.type", "boolean");
+    key.set_attribute("for", "edge");
+    key.set_attribute("id", "cyclehead");
 
     key.new_element("default").data="false";
   }

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -315,7 +315,7 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     xmlt &key=graphml.new_element("key");
     key.set_attribute("attr.name", "cyclehead");
     key.set_attribute("attr.type", "boolean");
-    key.set_attribute("for", "edge");
+    key.set_attribute("for", "node");
     key.set_attribute("id", "cyclehead");
 
     key.new_element("default").data="false";

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -54,6 +54,7 @@ static bool build_graph_rec(
     node.node_name=node_name;
     node.is_violation=false;
     node.has_invariant=false;
+    node.is_cyclehead=false;
 
     for(xmlt::elementst::const_iterator
         e_it=xml.elements.begin();
@@ -530,6 +531,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
       xmlt &val_s=node.new_element("data");
       val_s.set_attribute("key", "invariant.scope");
       val_s.data=n.invariant_scope;
+    }
+
+    // <node id="A14">
+    //     <data key="cyclehead">true</data>
+    // </node>
+    if(n.is_cyclehead)
+    {
+      xmlt &entry=node.new_element("data");
+      entry.set_attribute("key", "cyclehead");
+      entry.data="true";
     }
 
     for(graphmlt::edgest::const_iterator

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -394,6 +394,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "architecture");
   }
 
+  // <key attr.name="creationTime" attr.type="string" for="graph"
+  //      id="creationtime"/>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "creationTime");
+    key.set_attribute("attr.type", "string");
+    key.set_attribute("for", "graph");
+    key.set_attribute("id", "creationtime");
+  }
+
   // <key attr.name="producer" attr.type="string" for="graph"
   //      id="producer"/>
   {

--- a/src/xmllang/graphml.h
+++ b/src/xmllang/graphml.h
@@ -32,7 +32,6 @@ struct xml_graph_nodet:public graph_nodet<xml_edget>
   std::string node_name;
   irep_idt file;
   irep_idt line;
-  unsigned thread_nr;
   bool is_violation;
   bool has_invariant;
   std::string invariant;

--- a/src/xmllang/graphml.h
+++ b/src/xmllang/graphml.h
@@ -34,6 +34,7 @@ struct xml_graph_nodet:public graph_nodet<xml_edget>
   irep_idt line;
   bool is_violation;
   bool has_invariant;
+  bool is_cyclehead;
   std::string invariant;
   std::string invariant_scope;
 };


### PR DESCRIPTION
Dropped commits:
 - https://github.com/peterschrammel/cbmc/commit/75df82ee56f7f2b4456bf8c1d0d611cedbe9fc83 - constant propagation has undergone a lot of changes and the commit wasn't compatible. I've tried to reimplement it but since the module will be changed in future versions even more, it doesn't make sense to do so. (Moreover, constant propagation now works fine compared to 5.8)
 - https://github.com/peterschrammel/cbmc/commit/758c5399e7151e435648b2b7de77983f01bdd60e
 - https://github.com/peterschrammel/cbmc/commit/be84b19f810eb65bd247758b76b96bead124cc5a
 - https://github.com/peterschrammel/cbmc/commit/873ab6a35a5d5e164d70dabb1ca31a85d46c0e7e

New/modified:
- https://github.com/peterschrammel/cbmc/commit/5999b03a751292e055c0cd39d6f2820ad33a486a (it is no longer necessary to set the solver in a header file, everything is handled using Makefile now)
- https://github.com/peterschrammel/cbmc/commit/2caa58e9c17ee7a1da2861ef694cedfa5d37e5d5 
- https://github.com/peterschrammel/cbmc/commit/fcfe8855a4f6d63230fc310fa6e05126344732a9 the code wouldn't compile without this include