### PR TITLE
Rebase to 5.37

### DIFF
--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  if(*p == 0)
+    abort();
+  if(*p == 1)
+    exit(1);
+  if(*p == 2)
+    _Exit(1);
+  free(p);
+  return 0;
+}

--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int main()
 {
@@ -11,6 +11,8 @@ int main()
     exit(1);
   if(*p == 2)
     _Exit(1);
+  if(*p == 3)
+    __VERIFIER_error();
   free(p);
   return 0;
 }

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---memory-leak-check
+--memory-leak-check --no-assertions
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
@@ -8,5 +8,7 @@ _Exit\.memory-leak\.1.*FAILURE
 __CPROVER__start\.memory-leak\.1.*SUCCESS
 abort\.memory-leak\.1.*FAILURE
 exit\.memory-leak\.1.*FAILURE
+main\.memory-leak\.1.*FAILURE
 --
+main\.assertion\.1.*FAILURE
 ^warning: ignoring

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--memory-leak-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+_Exit\.memory-leak\.1.*FAILURE
+__CPROVER__start\.memory-leak\.1.*SUCCESS
+abort\.memory-leak\.1.*FAILURE
+exit\.memory-leak\.1.*FAILURE
+--
+^warning: ignoring

--- a/src/Makefile
+++ b/src/Makefile
@@ -115,7 +115,7 @@ $(patsubst %, %_clean, $(DIRS)):
 
 # minisat2 and glucose download, for your convenience
 
-DOWNLOADER = curl -L --remote-name
+DOWNLOADER = wget
 TAR = tar
 
 minisat2-download:

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -2143,7 +2143,8 @@ void goto_checkt::goto_check(
       if(
         enable_memory_leak_check && simplified_guard.is_false() &&
         (function_identifier == "abort" || function_identifier == "exit" ||
-         function_identifier == "_Exit"))
+         function_identifier == "_Exit" ||
+         (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))
       {
         memory_leak_check(function_identifier);
       }

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -2138,6 +2138,15 @@ void goto_checkt::goto_check(
     }
     else if(i.is_assume())
     {
+      // These are further 'exit points' of the program
+      const exprt simplified_guard = simplify_expr(i.guard, ns);
+      if(
+        enable_memory_leak_check && simplified_guard.is_false() &&
+        (function_identifier == "abort" || function_identifier == "exit" ||
+         function_identifier == "_Exit"))
+      {
+        memory_leak_check(function_identifier);
+      }
       if(!enable_assumptions)
       {
         i.turn_into_skip();

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -224,6 +224,7 @@ protected:
   void float_overflow_check(const exprt &, const guardt &);
   void nan_check(const exprt &, const guardt &);
   optionalt<exprt> rw_ok_check(exprt);
+  void memory_leak_check(const irep_idt &function_id);
 
   std::string array_name(const exprt &);
 
@@ -1854,6 +1855,54 @@ private:
   std::list<std::pair<bool *, bool>> flags_to_reset;
 };
 
+/*******************************************************************\
+
+Function: goto_checkt::memory_leak_check
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:
+
+\*******************************************************************/
+
+void goto_checkt::memory_leak_check(const irep_idt &function_id)
+{
+  const symbolt &leak=ns.lookup(CPROVER_PREFIX "memory_leak");
+  const symbol_exprt leak_expr=leak.symbol_expr();
+
+  // add self-assignment to get helpful counterexample output
+  code_assignt code(leak_expr, leak_expr);
+  goto_programt::instructiont t=goto_programt::make_assignment(code);
+
+  source_locationt source_location;
+  source_location.set_function(function_id);
+
+  equal_exprt eq(
+    leak_expr,
+    null_pointer_exprt(to_pointer_type(leak.type)));
+  add_guarded_property(
+    eq,
+    "dynamically allocated memory never freed",
+    "memory-leak",
+    source_location,
+    eq,
+    guardt(true_exprt(), guard_manager));
+}
+
+/*******************************************************************\
+
+Function: goto_checkt::goto_check
+
+  Inputs:
+
+ Outputs:
+
+ Purpose:[B
+
+\*******************************************************************/
+
 void goto_checkt::goto_check(
   const irep_idt &function_identifier,
   goto_functiont &goto_function)
@@ -2147,25 +2196,7 @@ void goto_checkt::goto_check(
         function_identifier == goto_functionst::entry_point() &&
         enable_memory_leak_check)
       {
-        const symbolt &leak=ns.lookup(CPROVER_PREFIX "memory_leak");
-        const symbol_exprt leak_expr=leak.symbol_expr();
-
-        // add self-assignment to get helpful counterexample output
-        new_code.add(goto_programt::make_assignment(leak_expr, leak_expr));
-
-        source_locationt source_location;
-        source_location.set_function(function_identifier);
-
-        equal_exprt eq(
-          leak_expr,
-          null_pointer_exprt(to_pointer_type(leak.type)));
-        add_guarded_property(
-          eq,
-          "dynamically allocated memory never freed",
-          "memory-leak",
-          source_location,
-          eq,
-          guardt(true_exprt(), guard_manager));
+        memory_leak_check(function_identifier);
       }
     }
 

--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -55,6 +55,7 @@ public:
     enable_bounds_check=_options.get_bool_option("bounds-check");
     enable_pointer_check=_options.get_bool_option("pointer-check");
     enable_memory_leak_check=_options.get_bool_option("memory-leak-check");
+    enable_memory_cleanup_check=_options.get_bool_option("memory-cleanup-check");
     enable_div_by_zero_check=_options.get_bool_option("div-by-zero-check");
     enable_enum_range_check = _options.get_bool_option("enum-range-check");
     enable_signed_overflow_check=
@@ -257,6 +258,7 @@ protected:
   bool enable_bounds_check;
   bool enable_pointer_check;
   bool enable_memory_leak_check;
+  bool enable_memory_cleanup_check;
   bool enable_div_by_zero_check;
   bool enable_enum_range_check;
   bool enable_signed_overflow_check;
@@ -2141,7 +2143,7 @@ void goto_checkt::goto_check(
       // These are further 'exit points' of the program
       const exprt simplified_guard = simplify_expr(i.guard, ns);
       if(
-        enable_memory_leak_check && simplified_guard.is_false() &&
+        enable_memory_cleanup_check && simplified_guard.is_false() &&
         (function_identifier == "abort" || function_identifier == "exit" ||
          function_identifier == "_Exit" ||
          (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))

--- a/src/analyses/goto_check.h
+++ b/src/analyses/goto_check.h
@@ -34,7 +34,7 @@ void goto_check(
   goto_modelt &goto_model);
 
 #define OPT_GOTO_CHECK                                                         \
-  "(bounds-check)(pointer-check)(memory-leak-check)"                           \
+  "(bounds-check)(pointer-check)(memory-leak-check)(memory-cleanup-check)"     \
   "(div-by-zero-check)(enum-range-check)(signed-overflow-check)(unsigned-"     \
   "overflow-check)"                                                            \
   "(pointer-overflow-check)(conversion-check)(undefined-shift-check)"          \
@@ -50,6 +50,7 @@ void goto_check(
   " --bounds-check               enable array bounds checks\n" \
   " --pointer-check              enable pointer checks\n" /* NOLINT(whitespace/line_length) */ \
   " --memory-leak-check          enable memory leak checks\n" \
+  " --memory-cleanup-check       enable memory cleanup checks\n" \
   " --div-by-zero-check          enable division by zero checks\n" \
   " --signed-overflow-check      enable signed arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */ \
   " --unsigned-overflow-check    enable arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */  \
@@ -71,6 +72,7 @@ void goto_check(
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
   options.set_option("pointer-check", cmdline.isset("pointer-check")); \
   options.set_option("memory-leak-check", cmdline.isset("memory-leak-check")); \
+  options.set_option("memory-cleanup-check", cmdline.isset("memory-cleanup-check")); \
   options.set_option("div-by-zero-check", cmdline.isset("div-by-zero-check")); \
   options.set_option("enum-range-check", cmdline.isset("enum-range-check")); \
   options.set_option("signed-overflow-check", cmdline.isset("signed-overflow-check")); /* NOLINT(whitespace/line_length) */  \

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -261,10 +261,12 @@ inline void free(void *ptr)
 
   // catch people who try to use free(...) for stuff
   // allocated with new[]
+#if 0
   __CPROVER_precondition(ptr==0 ||
                          __CPROVER_malloc_object!=ptr ||
                          !__CPROVER_malloc_is_new_array,
                          "free called for new[] object");
+#endif
 
   // catch people who try to use free(...) with alloca
   __CPROVER_precondition(

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,7 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations -Wswitch-enum
+  CXXFLAGS += -Wall -pedantic -Wno-deprecated-declarations -Wswitch-enum
 endif
 
 ifeq ($(CPROVER_WITH_PROFILING),1)

--- a/src/config.inc
+++ b/src/config.inc
@@ -31,7 +31,7 @@ endif
 #MINISAT = ../../MiniSat-p_v1.14
 #MINISAT2 = ../../minisat-2.2.1
 #IPASIR = ../../ipasir
-#GLUCOSE = ../../glucose-syrup
+GLUCOSE = ../../glucose-syrup
 #CADICAL = ../../cadical
 
 # select default solver to be minisat2 if no other is specified

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -730,6 +730,7 @@ void goto_convertt::do_function_call_symbol(
     // are being checked
     goto_programt::targett a = dest.add(goto_programt::make_assumption(
       false_exprt(), function.source_location()));
+    a->labels.push_back("__VERIFIER_abort");
     a->source_location.set("user-provided", true);
   }
   else if(

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -55,8 +55,10 @@ void goto_inline(
     ns,
     message_handler,
     adjust_function);
+  goto_inline();
+}
 
-  typedef goto_functionst::goto_functiont goto_functiont;
+void goto_inlinet::operator()() {
 
   // find entry point
   goto_functionst::function_mapt::iterator it=
@@ -95,7 +97,7 @@ void goto_inline(
     }
   }
 
-  goto_inline.goto_inline(
+  goto_inline(
     goto_functionst::entry_point(), entry_function, inline_map, true);
 
   // clean up

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -88,6 +88,11 @@ void goto_inlinet::parameter_assignments(
         {
           actual = typecast_exprt(actual, f_partype);
         }
+        else if(f_partype.id()==ID_floatbv &&
+                f_acttype.id()==ID_floatbv)
+        {
+          actual = typecast_exprt(actual, f_partype);
+        }
         else if((f_partype.id()==ID_signedbv ||
                  f_partype.id()==ID_unsignedbv ||
                  f_partype.id()==ID_bool) &&

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -338,6 +338,7 @@ void goto_inlinet::expand_function_call(
     log.warning().source_location = function.find_source_location();
     log.warning() << "recursion is ignored on call to '" << identifier << "'"
                   << messaget::eom;
+    is_recursion_detected=true;
 
     if(force_full)
       target->turn_into_skip();

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -42,7 +42,8 @@ public:
       goto_functions(goto_functions),
       ns(ns),
       adjust_function(adjust_function),
-      caching(caching)
+      caching(caching),
+      is_recursion_detected(false)
   {
   }
 
@@ -58,6 +59,9 @@ public:
 
   // list of calls per function that should be inlined
   typedef std::map<irep_idt, call_listt> inline_mapt;
+
+  void operator()();
+  bool recursion_detected() { return is_recursion_detected; }
 
   // handle given goto function
   // force_full:
@@ -140,6 +144,7 @@ protected:
 
   const bool adjust_function;
   const bool caching;
+  bool is_recursion_detected;
 
   goto_inline_logt inline_log;
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -412,9 +412,23 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     {
       // advance
     }
-    const std::size_t to=
-      next==goto_trace.steps.end()?
-      sink:step_to_node[next->step_nr];
+
+    std::size_t to=sink;
+    // nontermination lasso traces end in a backwards goto:
+    if(next==goto_trace.steps.end() &&
+       it->is_goto() && it->pc->is_backwards_goto())
+    {
+      goto_tracet::stepst::const_iterator last=it;
+      for(--last; last->pc==it->pc->get_target(); --last)
+        ;
+      // we'll close the loop
+      to=step_to_node[last->step_nr];
+    }
+    else
+    {
+      // advance to the next step
+      to=step_to_node[next->step_nr];
+    }
 
     switch(it->type)
     {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -415,21 +415,39 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     }
 
     std::size_t to=sink;
-    // nontermination lasso traces end in a backwards goto:
-    if(next==goto_trace.steps.end() &&
-       it->is_goto() && it->pc->is_backwards_goto())
+    if(next!=goto_trace.steps.end())
     {
-      goto_tracet::stepst::const_iterator last=it;
-      for(--last; last->pc==it->pc->get_target(); --last)
-        ;
-      // we'll close the loop
-      to=step_to_node[last->step_nr];
-      graphml[to].is_cyclehead=true;
+      goto_tracet::stepst::const_iterator after_next=next;
+      ++after_next;
+      // nontermination lasso traces do not end in assertions
+      if(after_next==goto_trace.steps.end() &&
+         !next->is_assert())
+      {
+        goto_tracet::stepst::const_iterator last=
+          goto_trace.steps.begin();
+        for(goto_tracet::stepst::const_iterator last_it=
+              goto_trace.steps.begin();
+            last_it!=goto_trace.steps.end() &&
+            last_it!=next;
+            ++last_it)
+        {
+          if(last_it->pc==next->pc)
+            last=last_it;
+        }
+        // we'll close the loop
+        to=step_to_node[last->step_nr];
+        graphml[to].is_cyclehead=true;
+      }
+      else
+      {
+        // advance to the next step
+        to=step_to_node[next->step_nr];
+      }
     }
-    else
+    else if(!it->is_assert())
     {
-      // advance to the next step
-      to=step_to_node[next->step_nr];
+      // do not output recurrent step in nontermination trace
+      break;
     }
 
     switch(it->type)

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -383,6 +383,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     graphml[node].is_violation=
       it->type==goto_trace_stept::typet::ASSERT && !it->cond_value;
     graphml[node].has_invariant=false;
+    graphml[node].is_cyclehead=false;
 
     step_to_node[it->step_nr]=node;
   }
@@ -423,6 +424,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         ;
       // we'll close the loop
       to=step_to_node[last->step_nr];
+      graphml[to].is_cyclehead=true;
     }
     else
     {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -471,10 +471,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         xmlt &data_l = edge.new_element("data");
         data_l.set_attribute("key", "startline");
         data_l.data = id2string(graphml[from].line);
-
-        xmlt &data_t = edge.new_element("data");
-        data_t.set_attribute("key", "threadId");
-        data_t.data = std::to_string(it->thread_nr);
       }
 
       const auto lhs_object = it->get_lhs_object();

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -113,9 +113,11 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   {
     const mp_integer offset = *index * byte_width;
 
-    for(std::size_t i=0; i<width; i++)
+    long offset_i=offset.to_long();
+
+    for(long i=0; i<(long)width; i++)
       // out of bounds?
-      if(offset + i < 0 || offset + i >= op_bv.size())
+      if(offset<0 || offset_i+i>=(long)op_bv.size())
         bv[i]=prop.new_variable();
       else
         bv[i] = op_bv[numeric_cast_v<std::size_t>(offset + i)];

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -81,6 +81,9 @@ public:
   void pop() override;
 
   std::size_t get_number_of_solver_calls() const override;
+  void convert_expr(const exprt &);
+  void convert_type(const typet &);
+  void convert_literal(const literalt);
 
   static std::string convert_identifier(const irep_idt &identifier);
 
@@ -138,10 +141,6 @@ protected:
 
   void convert_with(const with_exprt &expr);
   void convert_update(const exprt &expr);
-
-  void convert_expr(const exprt &);
-  void convert_type(const typet &);
-  void convert_literal(const literalt);
 
   literalt convert(const exprt &expr);
   tvt l_get(literalt l) const;

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -413,6 +413,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
 
   if(expr.type().id() == ID_floatbv)
   {
+#if 0
     // we only merge neighboring constants!
     Forall_expr(it, new_operands)
     {
@@ -430,6 +431,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
         }
       }
     }
+#endif
   }
   else
   {

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -587,9 +587,11 @@ simplify_exprt::simplify_is_dynamic_object(const unary_exprt &expr)
     {
       const irep_idt identifier = to_symbol_expr(op_object).get_identifier();
 
+      address_of_exprt op=to_address_of_expr(op);
       // this is for the benefit of symex
       return make_boolean_expr(
-        has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX));
+        has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX) ||
+          op.object().type().get_bool("#dynamic"));
     }
     else if(op_object.id() == ID_string_constant)
     {

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -390,6 +390,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "architecture");
   }
 
+  // <key attr.name="creationTime" attr.type="string" for="graph"
+  //      id="creationtime"/>
+  {
+    xmlt &key=graphml.new_element("key");
+    key.set_attribute("attr.name", "creationTime");
+    key.set_attribute("attr.type", "string");
+    key.set_attribute("for", "graph");
+    key.set_attribute("id", "creationtime");
+  }
+
   // <key attr.name="producer" attr.type="string" for="graph"
   //      id="producer"/>
   {

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -50,6 +50,7 @@ static bool build_graph_rec(
     node.node_name=node_name;
     node.is_violation=false;
     node.has_invariant=false;
+    node.is_cyclehead=false;
 
     for(xmlt::elementst::const_iterator
         e_it=xml.elements.begin();
@@ -536,6 +537,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
       xmlt &val_s=node.new_element("data");
       val_s.set_attribute("key", "invariant.scope");
       val_s.data=n.invariant_scope;
+    }
+
+    // <node id="A14">
+    //     <data key="cyclehead">true</data>
+    // </node>
+    if(n.is_cyclehead)
+    {
+      xmlt &entry=node.new_element("data");
+      entry.set_attribute("key", "cyclehead");
+      entry.data="true";
     }
 
     for(graphmlt::edgest::const_iterator

--- a/src/xmllang/graphml.h
+++ b/src/xmllang/graphml.h
@@ -34,6 +34,7 @@ struct xml_graph_nodet:public graph_nodet<xml_edget>
   irep_idt line;
   bool is_violation;
   bool has_invariant;
+  bool is_cyclehead;
   std::string invariant;
   std::string invariant_scope;
 };


### PR DESCRIPTION
Apologies to the code owners who receive a mention from this PR, this is hopefully the last time :-)

Not a lot of changes this time:
 - dropped https://github.com/peterschrammel/cbmc/commit/18306afde439ca23787cb51ec6ae075270bdac94
 - a small merge conflict in https://github.com/peterschrammel/cbmc/commit/e04e4998a237e655098ec0d36ab312707100f884 , very easy to fix
 - I had to modify https://github.com/peterschrammel/cbmc/commit/675beef80008e12557755637b721add0ee850096 a little bit due to deprecation of `exprt.opX()`, just a simple cast
 - Also modified https://github.com/peterschrammel/cbmc/commit/cfc548d29eba8d774b38784d0379c35272dcdd68 to consider changes to `make_assignment` method of a GOTO instruction, also fairly simple.
 - I was also able to drop the temporary commit removing `printf` implementation