### PR TITLE
SV-COMP 22 fixes

### DIFF
--- a/src/analyses/goto_check.cpp
+++ b/src/analyses/goto_check.cpp
@@ -2142,13 +2142,17 @@ void goto_checkt::goto_check(
     {
       // These are further 'exit points' of the program
       const exprt simplified_guard = simplify_expr(i.guard, ns);
+      // The function may be inlined to only __CPROVER_start, use the
+      // original location (if it is still valid thanks to setting
+      // adjust_false=false in goto_inlinet).
+      const irep_idt &former_function = i.source_location.get_function();
       if(
         enable_memory_cleanup_check && simplified_guard.is_false() &&
-        (function_identifier == "abort" || function_identifier == "exit" ||
-         function_identifier == "_Exit" ||
+        (former_function == "abort" || former_function == "exit" ||
+         former_function == "_Exit" ||
          (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))
       {
-        memory_leak_check(function_identifier);
+        memory_leak_check(former_function);
       }
       if(!enable_assumptions)
       {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -246,8 +246,10 @@ static bool filter_out(
      prev_it->pc->source_location==it->pc->source_location)
     return true;
 
+#if 0
   if(it->is_goto() && it->pc->get_condition().is_true())
     return true;
+#endif
 
   const source_locationt &source_location=it->pc->source_location;
 

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -390,16 +390,6 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
     key.set_attribute("id", "architecture");
   }
 
-  // <key attr.name="creationTime" attr.type="string" for="graph"
-  //      id="creationtime"/>
-  {
-    xmlt &key=graphml.new_element("key");
-    key.set_attribute("attr.name", "creationTime");
-    key.set_attribute("attr.type", "string");
-    key.set_attribute("for", "graph");
-    key.set_attribute("id", "creationtime");
-  }
-
   // <key attr.name="producer" attr.type="string" for="graph"
   //      id="producer"/>
   {


### PR DESCRIPTION
@peterschrammel this is a fix for SVcomp, the same change that we had in our fork was applied in the develop branch ( see https://github.com/diffblue/cbmc/pull/5660 ) so it is no longer necessary. Reverting for now, we can drop these commits if we later rebase to a newer version.