### PR TITLE
Rebase to 5.61

### DIFF
--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+
+extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+
+int main()
+{
+  int *p = malloc(sizeof(int));
+  if(*p == 0)
+    abort();
+  if(*p == 1)
+    exit(1);
+  if(*p == 2)
+    _Exit(1);
+  free(p);
+  return 0;
+}

--- a/regression/cbmc/Memory_leak_abort/main.c
+++ b/regression/cbmc/Memory_leak_abort/main.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-extern void __VERIFIER_error() __attribute__ ((__noreturn__));
+extern void __VERIFIER_error() __attribute__((__noreturn__));
 
 int main()
 {
@@ -11,6 +11,8 @@ int main()
     exit(1);
   if(*p == 2)
     _Exit(1);
+  if(*p == 3)
+    __VERIFIER_error();
   free(p);
   return 0;
 }

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
---memory-leak-check
+--memory-leak-check --no-assertions
 ^EXIT=10$
 ^SIGNAL=0$
 ^VERIFICATION FAILED$
@@ -8,5 +8,7 @@ _Exit\.memory-leak\.1.*FAILURE
 __CPROVER__start\.memory-leak\.1.*SUCCESS
 abort\.memory-leak\.1.*FAILURE
 exit\.memory-leak\.1.*FAILURE
+main\.memory-leak\.1.*FAILURE
 --
+main\.assertion\.1.*FAILURE
 ^warning: ignoring

--- a/regression/cbmc/Memory_leak_abort/test.desc
+++ b/regression/cbmc/Memory_leak_abort/test.desc
@@ -1,0 +1,12 @@
+CORE
+main.c
+--memory-leak-check
+^EXIT=10$
+^SIGNAL=0$
+^VERIFICATION FAILED$
+_Exit\.memory-leak\.1.*FAILURE
+__CPROVER__start\.memory-leak\.1.*SUCCESS
+abort\.memory-leak\.1.*FAILURE
+exit\.memory-leak\.1.*FAILURE
+--
+^warning: ignoring

--- a/src/Makefile
+++ b/src/Makefile
@@ -121,7 +121,7 @@ $(patsubst %, %_clean, $(DIRS)):
 
 # minisat2 and glucose download, for your convenience
 
-DOWNLOADER = curl -L --remote-name
+DOWNLOADER = wget
 TAR = tar
 
 minisat2-download:

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -56,6 +56,7 @@ public:
     enable_bounds_check = _options.get_bool_option("bounds-check");
     enable_pointer_check = _options.get_bool_option("pointer-check");
     enable_memory_leak_check = _options.get_bool_option("memory-leak-check");
+    enable_memory_cleanup_check=_options.get_bool_option("memory-cleanup-check");
     enable_div_by_zero_check = _options.get_bool_option("div-by-zero-check");
     enable_enum_range_check = _options.get_bool_option("enum-range-check");
     enable_signed_overflow_check =
@@ -258,6 +259,7 @@ protected:
   bool enable_bounds_check;
   bool enable_pointer_check;
   bool enable_memory_leak_check;
+  bool enable_memory_cleanup_check;
   bool enable_div_by_zero_check;
   bool enable_enum_range_check;
   bool enable_signed_overflow_check;

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -225,6 +225,7 @@ protected:
   void float_overflow_check(const exprt &, const guardt &);
   void nan_check(const exprt &, const guardt &);
   optionalt<exprt> rw_ok_check(exprt);
+  void memory_leak_check(const irep_idt &function_id);
 
   std::string array_name(const exprt &);
 
@@ -2032,6 +2033,44 @@ optionalt<exprt> goto_check_ct::rw_ok_check(exprt expr)
     return {};
 }
 
+/*******************************************************************\
+Function: goto_check_ct::memory_leak_check
+  Inputs:
+ Outputs:
+ Purpose:
+\*******************************************************************/
+
+void goto_check_ct::memory_leak_check(const irep_idt &function_id)
+{
+  const symbolt &leak=ns.lookup(CPROVER_PREFIX "memory_leak");
+  const symbol_exprt leak_expr=leak.symbol_expr();
+
+  // add self-assignment to get helpful counterexample output
+  code_assignt code(leak_expr, leak_expr);
+  goto_programt::instructiont t=goto_programt::make_assignment(code);
+
+  source_locationt source_location;
+  source_location.set_function(function_id);
+
+  equal_exprt eq(
+    leak_expr,
+    null_pointer_exprt(to_pointer_type(leak.type)));
+  add_guarded_property(
+    eq,
+    "dynamically allocated memory never freed",
+    "memory-leak",
+    source_location,
+    eq,
+    identity);
+}
+
+/*******************************************************************\
+Function: goto_checkt::goto_check
+  Inputs:
+ Outputs:
+ Purpose:[B
+\*******************************************************************/
+
 void goto_check_ct::goto_check(
   const irep_idt &function_identifier,
   goto_functiont &goto_function)
@@ -2207,24 +2246,7 @@ void goto_check_ct::goto_check(
         function_identifier == goto_functionst::entry_point() &&
         enable_memory_leak_check)
       {
-        const symbolt &leak = ns.lookup(CPROVER_PREFIX "memory_leak");
-        const symbol_exprt leak_expr = leak.symbol_expr();
-
-        // add self-assignment to get helpful counterexample output
-        new_code.add(goto_programt::make_assignment(leak_expr, leak_expr));
-
-        source_locationt source_location;
-        source_location.set_function(function_identifier);
-
-        equal_exprt eq(
-          leak_expr, null_pointer_exprt(to_pointer_type(leak.type)));
-        add_guarded_property(
-          eq,
-          "dynamically allocated memory never freed",
-          "memory-leak",
-          source_location,
-          eq,
-          identity);
+        memory_leak_check(function_identifier);
       }
     }
 

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -2227,7 +2227,8 @@ void goto_check_ct::goto_check(
       if(
         enable_memory_cleanup_check && simplified_guard.is_false() &&
         (former_function == "abort" || former_function == "exit" ||
-         former_function == "_Exit"))
+         former_function == "_Exit" ||
+         (i.labels.size() == 1 && i.labels.front() == "__VERIFIER_abort")))
       {
         memory_leak_check(former_function);
       }

--- a/src/ansi-c/goto_check_c.cpp
+++ b/src/ansi-c/goto_check_c.cpp
@@ -2216,6 +2216,22 @@ void goto_check_ct::goto_check(
       // this has no successor
       assertions.clear();
     }
+    else if(i.is_assume())
+    {
+      // These are further 'exit points' of the program
+      const exprt simplified_guard = simplify_expr(i.condition(), ns);
+      // The function may be inlined to only __CPROVER_start, use the
+      // original location (if it is still valid thanks to setting
+      // adjust_false=false in goto_inlinet).
+      const irep_idt &former_function = i.source_location().get_function();
+      if(
+        enable_memory_cleanup_check && simplified_guard.is_false() &&
+        (former_function == "abort" || former_function == "exit" ||
+         former_function == "_Exit"))
+      {
+        memory_leak_check(former_function);
+      }
+    }
     else if(i.is_dead())
     {
       if(enable_pointer_check || enable_pointer_primitive_check)

--- a/src/ansi-c/goto_check_c.h
+++ b/src/ansi-c/goto_check_c.h
@@ -38,7 +38,7 @@ void goto_check_c(
   message_handlert &message_handler);
 
 #define OPT_GOTO_CHECK                                                         \
-  "(bounds-check)(pointer-check)(memory-leak-check)"                           \
+  "(bounds-check)(pointer-check)(memory-leak-check)(memory-cleanup-check)"     \
   "(div-by-zero-check)(enum-range-check)"                                      \
   "(signed-overflow-check)(unsigned-overflow-check)"                           \
   "(pointer-overflow-check)(conversion-check)(undefined-shift-check)"          \
@@ -54,6 +54,7 @@ void goto_check_c(
   " --bounds-check               enable array bounds checks\n" \
   " --pointer-check              enable pointer checks\n" /* NOLINT(whitespace/line_length) */ \
   " --memory-leak-check          enable memory leak checks\n" \
+  " --memory-cleanup-check       enable memory cleanup checks\n" \
   " --div-by-zero-check          enable division by zero checks\n" \
   " --signed-overflow-check      enable signed arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */ \
   " --unsigned-overflow-check    enable arithmetic over- and underflow checks\n" /* NOLINT(whitespace/line_length) */  \
@@ -75,6 +76,7 @@ void goto_check_c(
   options.set_option("bounds-check", cmdline.isset("bounds-check")); \
   options.set_option("pointer-check", cmdline.isset("pointer-check")); \
   options.set_option("memory-leak-check", cmdline.isset("memory-leak-check")); \
+  options.set_option("memory-cleanup-check", cmdline.isset("memory-cleanup-check")); \
   options.set_option("div-by-zero-check", cmdline.isset("div-by-zero-check")); \
   options.set_option("enum-range-check", cmdline.isset("enum-range-check")); \
   options.set_option("signed-overflow-check", cmdline.isset("signed-overflow-check")); /* NOLINT(whitespace/line_length) */  \

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -280,9 +280,11 @@ void free(void *ptr)
 
   // catch people who try to use free(...) for stuff
   // allocated with new[]
+#if 0
   __CPROVER_precondition(
     ptr == 0 || __CPROVER_new_object != ptr || !__CPROVER_malloc_is_new_array,
     "free called for new[] object");
+#endif
 
   // catch people who try to use free(...) with alloca
   __CPROVER_precondition(

--- a/src/ansi-c/library/stdlib.c
+++ b/src/ansi-c/library/stdlib.c
@@ -619,6 +619,7 @@ __CPROVER_bool __VERIFIER_nondet___CPROVER_bool();
 
 void __CPROVER_deallocate(void *ptr)
 {
-  if(__VERIFIER_nondet___CPROVER_bool())
+  __CPROVER_bool record=__VERIFIER_nondet___CPROVER_bool();
+  if(record)
     __CPROVER_deallocated = ptr;
 }

--- a/src/config.inc
+++ b/src/config.inc
@@ -5,7 +5,7 @@ BUILD_ENV = AUTO
 ifeq ($(BUILD_ENV),MSVC)
   #CXXFLAGS += /Wall /WX
 else
-  CXXFLAGS += -Wall -pedantic -Werror -Wno-deprecated-declarations -Wswitch-enum
+  CXXFLAGS += -Wall -pedantic -Wno-deprecated-declarations -Wswitch-enum
 endif
 
 ifeq ($(CPROVER_WITH_PROFILING),1)

--- a/src/config.inc
+++ b/src/config.inc
@@ -31,7 +31,7 @@ endif
 #MINISAT = ../../MiniSat-p_v1.14
 #MINISAT2 = ../../minisat-2.2.1
 #IPASIR = ../../ipasir
-#GLUCOSE = ../../glucose-syrup
+GLUCOSE = ../../glucose-syrup
 #CADICAL = ../../cadical
 
 # select default solver to be minisat2 if no other is specified

--- a/src/goto-programs/builtin_functions.cpp
+++ b/src/goto-programs/builtin_functions.cpp
@@ -821,6 +821,7 @@ void goto_convertt::do_function_call_symbol(
     // are being checked
     goto_programt::targett a = dest.add(goto_programt::make_assumption(
       false_exprt(), function.source_location()));
+    a->labels.push_back("__VERIFIER_abort");
     a->source_location_nonconst().set("user-provided", true);
   }
   else if(

--- a/src/goto-programs/goto_inline.cpp
+++ b/src/goto-programs/goto_inline.cpp
@@ -55,8 +55,10 @@ void goto_inline(
     ns,
     message_handler,
     adjust_function);
+  goto_inline();
+}
 
-  typedef goto_functionst::goto_functiont goto_functiont;
+void goto_inlinet::operator()() {
 
   // find entry point
   goto_functionst::function_mapt::iterator it=
@@ -95,7 +97,7 @@ void goto_inline(
     }
   }
 
-  goto_inline.goto_inline(
+  goto_inline(
     goto_functionst::entry_point(), entry_function, inline_map, true);
 
   // clean up

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -89,6 +89,11 @@ void goto_inlinet::parameter_assignments(
         {
           actual = typecast_exprt(actual, f_partype);
         }
+        else if(f_partype.id()==ID_floatbv &&
+                f_acttype.id()==ID_floatbv)
+        {
+          actual = typecast_exprt(actual, f_partype);
+        }
         else if((f_partype.id()==ID_signedbv ||
                  f_partype.id()==ID_unsignedbv ||
                  f_partype.id()==ID_bool) &&

--- a/src/goto-programs/goto_inline_class.cpp
+++ b/src/goto-programs/goto_inline_class.cpp
@@ -338,6 +338,7 @@ void goto_inlinet::expand_function_call(
     log.warning().source_location = function.find_source_location();
     log.warning() << "recursion is ignored on call to '" << identifier << "'"
                   << messaget::eom;
+    is_recursion_detected=true;
 
     if(force_full)
       target->turn_into_skip();

--- a/src/goto-programs/goto_inline_class.h
+++ b/src/goto-programs/goto_inline_class.h
@@ -42,7 +42,8 @@ public:
       goto_functions(goto_functions),
       ns(ns),
       adjust_function(adjust_function),
-      caching(caching)
+      caching(caching),
+      is_recursion_detected(false)
   {
   }
 
@@ -58,6 +59,9 @@ public:
 
   // list of calls per function that should be inlined
   typedef std::map<irep_idt, call_listt> inline_mapt;
+
+  void operator()();
+  bool recursion_detected() { return is_recursion_detected; }
 
   // handle given goto function
   // force_full:
@@ -140,6 +144,7 @@ protected:
 
   const bool adjust_function;
   const bool caching;
+  bool is_recursion_detected;
 
   goto_inline_logt inline_log;
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -246,8 +246,10 @@ static bool filter_out(
     prev_it->pc->source_location() == it->pc->source_location())
     return true;
 
+#if 0
   if(it->is_goto() && it->pc->condition().is_true())
     return true;
+#endif
 
   const source_locationt &source_location = it->pc->source_location();
 

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -472,10 +472,6 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         xmlt &data_l = edge.new_element("data");
         data_l.set_attribute("key", "startline");
         data_l.data = id2string(graphml[from].line);
-
-        xmlt &data_t = edge.new_element("data");
-        data_t.set_attribute("key", "threadId");
-        data_t.data = std::to_string(it->thread_nr);
       }
 
       const auto lhs_object = it->get_lhs_object();

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -413,9 +413,23 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     {
       // advance
     }
-    const std::size_t to=
-      next==goto_trace.steps.end()?
-      sink:step_to_node[next->step_nr];
+
+    std::size_t to=sink;
+    // nontermination lasso traces end in a backwards goto:
+    if(next==goto_trace.steps.end() &&
+       it->is_goto() && it->pc->is_backwards_goto())
+    {
+      goto_tracet::stepst::const_iterator last=it;
+      for(--last; last->pc==it->pc->get_target(); --last)
+        ;
+      // we'll close the loop
+      to=step_to_node[last->step_nr];
+    }
+    else
+    {
+      // advance to the next step
+      to=step_to_node[next->step_nr];
+    }
 
     switch(it->type)
     {

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -416,21 +416,39 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     }
 
     std::size_t to=sink;
-    // nontermination lasso traces end in a backwards goto:
-    if(next==goto_trace.steps.end() &&
-       it->is_goto() && it->pc->is_backwards_goto())
+    if(next!=goto_trace.steps.end())
     {
-      goto_tracet::stepst::const_iterator last=it;
-      for(--last; last->pc==it->pc->get_target(); --last)
-        ;
-      // we'll close the loop
-      to=step_to_node[last->step_nr];
-      graphml[to].is_cyclehead=true;
+      goto_tracet::stepst::const_iterator after_next=next;
+      ++after_next;
+      // nontermination lasso traces do not end in assertions
+      if(after_next==goto_trace.steps.end() &&
+         !next->is_assert())
+      {
+        goto_tracet::stepst::const_iterator last=
+          goto_trace.steps.begin();
+        for(goto_tracet::stepst::const_iterator last_it=
+              goto_trace.steps.begin();
+            last_it!=goto_trace.steps.end() &&
+            last_it!=next;
+            ++last_it)
+        {
+          if(last_it->pc==next->pc)
+            last=last_it;
+        }
+        // we'll close the loop
+        to=step_to_node[last->step_nr];
+        graphml[to].is_cyclehead=true;
+      }
+      else
+      {
+        // advance to the next step
+        to=step_to_node[next->step_nr];
+      }
     }
-    else
+    else if(!it->is_assert())
     {
-      // advance to the next step
-      to=step_to_node[next->step_nr];
+      // do not output recurrent step in nontermination trace
+      break;
     }
 
     switch(it->type)

--- a/src/goto-programs/graphml_witness.cpp
+++ b/src/goto-programs/graphml_witness.cpp
@@ -384,6 +384,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
     graphml[node].is_violation=
       it->type==goto_trace_stept::typet::ASSERT && !it->cond_value;
     graphml[node].has_invariant=false;
+    graphml[node].is_cyclehead=false;
 
     step_to_node[it->step_nr]=node;
   }
@@ -424,6 +425,7 @@ void graphml_witnesst::operator()(const goto_tracet &goto_trace)
         ;
       // we'll close the loop
       to=step_to_node[last->step_nr];
+      graphml[to].is_cyclehead=true;
     }
     else
     {

--- a/src/solvers/flattening/boolbv_byte_extract.cpp
+++ b/src/solvers/flattening/boolbv_byte_extract.cpp
@@ -110,9 +110,11 @@ bvt boolbvt::convert_byte_extract(const byte_extract_exprt &expr)
   {
     const mp_integer offset = *index * byte_width;
 
-    for(std::size_t i=0; i<width; i++)
+    long offset_i=offset.to_long();
+
+    for(long i=0; i<(long)width; i++)
       // out of bounds?
-      if(offset + i < 0 || offset + i >= op_bv.size())
+      if(offset<0 || offset_i+i>=(long)op_bv.size())
         bv[i]=prop.new_variable();
       else
         bv[i] = op_bv[numeric_cast_v<std::size_t>(offset + i)];

--- a/src/solvers/smt2/smt2_conv.h
+++ b/src/solvers/smt2/smt2_conv.h
@@ -82,6 +82,9 @@ public:
   void pop() override;
 
   std::size_t get_number_of_solver_calls() const override;
+  void convert_expr(const exprt &);
+  void convert_type(const typet &);
+  void convert_literal(const literalt);
 
   static std::string convert_identifier(const irep_idt &identifier);
 
@@ -139,10 +142,6 @@ protected:
 
   void convert_with(const with_exprt &expr);
   void convert_update(const exprt &expr);
-
-  void convert_expr(const exprt &);
-  void convert_type(const typet &);
-  void convert_literal(const literalt);
 
   literalt convert(const exprt &expr);
   tvt l_get(literalt l) const;

--- a/src/util/simplify_expr_int.cpp
+++ b/src/util/simplify_expr_int.cpp
@@ -413,6 +413,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
 
   if(expr.type().id() == ID_floatbv)
   {
+#if 0
     // we only merge neighboring constants!
     Forall_expr(it, new_operands)
     {
@@ -430,6 +431,7 @@ simplify_exprt::resultt<> simplify_exprt::simplify_plus(const plus_exprt &expr)
         }
       }
     }
+#endif
   }
   else
   {

--- a/src/util/simplify_expr_pointer.cpp
+++ b/src/util/simplify_expr_pointer.cpp
@@ -592,9 +592,11 @@ simplify_exprt::simplify_is_dynamic_object(const unary_exprt &expr)
     {
       const irep_idt identifier = to_symbol_expr(op_object).get_identifier();
 
+      address_of_exprt op=to_address_of_expr(op);
       // this is for the benefit of symex
       return make_boolean_expr(
-        has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX));
+        has_prefix(id2string(identifier), SYMEX_DYNAMIC_PREFIX) ||
+          op.object().type().get_bool("#dynamic"));
     }
     else if(op_object.id() == ID_string_constant)
     {

--- a/src/xmllang/graphml.cpp
+++ b/src/xmllang/graphml.cpp
@@ -50,6 +50,7 @@ static bool build_graph_rec(
     node.node_name=node_name;
     node.is_violation=false;
     node.has_invariant=false;
+    node.is_cyclehead=false;
 
     for(xmlt::elementst::const_iterator
         e_it=xml.elements.begin();
@@ -536,6 +537,16 @@ bool write_graphml(const graphmlt &src, std::ostream &os)
       xmlt &val_s=node.new_element("data");
       val_s.set_attribute("key", "invariant.scope");
       val_s.data=n.invariant_scope;
+    }
+
+    // <node id="A14">
+    //     <data key="cyclehead">true</data>
+    // </node>
+    if(n.is_cyclehead)
+    {
+      xmlt &entry=node.new_element("data");
+      entry.set_attribute("key", "cyclehead");
+      entry.data="true";
     }
 
     for(graphmlt::edgest::const_iterator

--- a/src/xmllang/graphml.h
+++ b/src/xmllang/graphml.h
@@ -36,6 +36,7 @@ struct xml_graph_nodet:public graph_nodet<xml_edget>
   irep_idt line;
   bool is_violation;
   bool has_invariant;
+  bool is_cyclehead;
   std::string invariant;
   std::string invariant_scope;
 };


### PR DESCRIPTION
[Apologies to code owners if this requests a review]

Not many important changes during the rebase of CBMC, mainly:
 - dropped merge commits (please rebase this PR onto the target branch so that we avoid merge commits for cleaner "extra history")
 - squashed one revert commit
 - removed FMOD fixed (applied in CBMC 5.43)
 - goto_check changes for memory leak safety resulted in a lot of merge conflicts (files moving around, refactoring of the classes). Transformation of assertions were moved to a separate function (they are language agnostic), however I've kept 2LS specific transformations inside `goto_check_ct` since they are C-specific.
 - I had to add https://github.com/peterschrammel/cbmc/commit/9e17fc721f1609cf3c147038b49e63cd51fedaa6 for compatibility with heap domain template in 2LS (probably can be removed in the future if we modify the underlying algorithms slightly).